### PR TITLE
Fixed missing skinId on exchange_skin_handle

### DIFF
--- a/cstrike/addons/amxmodx/scripting/csgo_core.sma
+++ b/cstrike/addons/amxmodx/scripting/csgo_core.sma
@@ -1524,6 +1524,7 @@ public exchange_skin_handle(id, menu, item)
 
 		formatex(menuData, charsmax(menuData), "%L", id, "CSGO_CORE_EXCHANGE_THEIR_ITEM", skin[SKIN_NAME], skin[SKIN_WEAPON_SHORT], skin[SKIN_RARITY]);
 
+		num_to_str(skinId, tempId, charsmax(tempId));
 		menu_additem(menu, menuData, tempId);
 
 		skinsCount++;


### PR DESCRIPTION
There was a problem on exchange menu that prevents players to exchange skins, with message bellow:

[CSGO_CORE_EXCHANGE_NO_SKIN](https://github.com/TheDoctor0/CSGOMod/blob/386c68ad38b0604f16022fb9b32c3a6abad5a861/cstrike/addons/amxmodx/data/lang/csgomod.txt#L462)

So we figured out that `tempId` was empty.

by team: @OffensiveBrasil 